### PR TITLE
Revert getSession

### DIFF
--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -77,7 +77,6 @@ describe('App', () => {
       fireEvent.change(screen.getByLabelText(/add a note/i), {
         target: { value: 'another note' },
       });
-      screen.debug();
       const tagForm = screen.getByRole('form', { name: 'new-tag-form' });
       expect(tagForm.textContent).toMatch(/meta(.*)work/i);
 

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -36,7 +36,7 @@ afterAll(() => {
 });
 
 describe('getSession', () => {
-  it('', async () => {
+  it('gets user', async () => {
     const api = createApi();
     const user = await api.getUser();
     expect(user).toEqual({ id: '123' });

--- a/src/api.js
+++ b/src/api.js
@@ -34,11 +34,9 @@ export const createApi = (db = supabase) => {
   const getSession = () => db.auth.getSession();
 
   const getUser = async () => {
-    const res = await db.auth.getSession();
+    const res = await db.auth.getUser();
     console.log('res', res);
-    const {
-      session: { user },
-    } = validate(res);
+    const { user } = validate(res);
     return user;
   };
 


### PR DESCRIPTION
## What problem does this solve?

https://github.com/helloitsjoe/jot/commit/45fb4825da0919fa106818e83234ae7b218e012a caused issues with tests, since `getSession` relies on local storage and does not make a request for the user on every `getSession` call. I decided to go back to `getUser` since it's more reliable and the Supabase docs recommend it: https://supabase.com/docs/reference/javascript/auth-getuser